### PR TITLE
fix(js): stop resetting vis on jsonInput if unnecessary

### DIFF
--- a/vue-components/src/components/TrameDeck.js
+++ b/vue-components/src/components/TrameDeck.js
@@ -1,4 +1,4 @@
-import { createDeck } from '@deck.gl/jupyter-widget';
+import { createDeck, updateDeck } from '@deck.gl/jupyter-widget';
 
 export default {
   name: 'TrameDeck',
@@ -19,9 +19,17 @@ export default {
   },
   watch: {
     async jsonInput() {
+      if (this.viz) {
+        updateDeck(this.jsonInput, this.viz);
+        return;
+      }
       await this.mountVis();
     },
     async opt() {
+      if (this.viz) {
+        updateDeck(this.jsonInput, this.viz);
+        return;
+      }
       await this.mountVis();
     },
   },


### PR DESCRIPTION
PR made for the fennil project (https://github.com/brendanjmeade/fennil/issues/4). When json properties for the map were updated, it caused the map to reset its zoom/pan.